### PR TITLE
Fix bug #94

### DIFF
--- a/themes/freecycle/wanted-list.php
+++ b/themes/freecycle/wanted-list.php
@@ -1,6 +1,6 @@
 <script>
 	
-	onClickSearchWantedList(0,"<?php echo (urldecode($_GET['item_name'])) ?>");
+	onClickSearchWantedList(0,"<?php echo isset($_GET['item_name'])?urldecode($_GET['item_name']):'' ?>");
 		
 		
 	//Enter押下時読み込まれる関数


### PR DESCRIPTION
This bug occured only when WP_DEBUG_DISPLAY was true in wp-config.php.
It was because it was not checked if 'keyword' value was set in $_GET.
To fix this, isset method was implemented.
Basically, isset method should be used anytime any values specified by name are taken from allay.