### PR TITLE
Enhance check trade log from dashboard

### DIFF
--- a/plugins/freecycle/functions.php
+++ b/plugins/freecycle/functions.php
@@ -31,6 +31,7 @@ remove_filter( 'bp_get_the_profile_field_value', 'xprofile_filter_link_profile_d
 require_once('functions.kses.php');
 require_once('categories/freecycle-categories.php');
 require_once('map/freecycle-map.php');
+require_once('trade-log/freecycle-trade-log.php');
 
 //写真を自動で回転して縦にする
 function edit_images_before_upload($file)

--- a/plugins/freecycle/trade-log/freecycle-trade-log.php
+++ b/plugins/freecycle/trade-log/freecycle-trade-log.php
@@ -1,13 +1,19 @@
 <?php
+// 取引状態を表す定数群
+define('FC_TRADE_FINISHED', 'finished'); // 取引完了
+define('FC_TRADE_BIDDER_EVALUATED', 'bidder_evaluated'); // 取引相手評価済
+define('FC_TRADE_EXHIBITOR_EVALUATED', 'exhibitor_evaluated'); // 出品者評価済
+define('FC_TRADE_ITEM_PASSED', 'item_passed'); // 商品受け渡し済
+define('FC_TRADE_CONFIRMED', 'confirmed'); // 取引相手確定済
+define('FC_TRADE_GIVEMEED', 'givemed'); // ください済
+define('FC_TRADE_ENTRIED', 'entried'); // 出品済
+define('FC_TRADE_UNKNOWN', 'unknown'); // 不明
 
-define('FC_TRADE_FINISHED', 'finished');
-define('FC_TRADE_BIDDER_EVALUATED', 'bidder_evaluated');
-define('FC_TRADE_EXHIBITOR_EVALUATED', 'exhibitor_evaluated');
-define('FC_TRADE_ITEM_PASSED', 'item_passed');
-define('FC_TRADE_CONFIRMED', 'confirmed');
-define('FC_TRADE_GIVEMEED', 'givemed');
-define('FC_TRADE_ENTRIED', 'entried');
-
+/**
+ * 取引状態を定数値で返します。
+ * @param {int} $id 商品ID(postID)
+ * @return {string} 取引状態の定数値を返します。詳細は上の定数群を参照してください。
+ */
 function get_trade_status($id){
 	if(isFinish($id) && isBidderEvaluated($id) && isExhibiterEvaluated($id)){
 		return FC_TRADE_FINISHED;
@@ -23,8 +29,9 @@ function get_trade_status($id){
 		return FC_TRADE_GIVEMEED;
 	}else if(!isGiveme($id) && isEntry($id)){
 		return FC_TRADE_ENTRIED;
+	}else{
+		return FC_TRADE_UNKNOWN;
 	}
-
 }
 
 /**

--- a/plugins/freecycle/trade-log/freecycle-trade-log.php
+++ b/plugins/freecycle/trade-log/freecycle-trade-log.php
@@ -1,0 +1,171 @@
+<?php
+
+define('FC_TRADE_FINISHED', 'finished');
+define('FC_TRADE_BIDDER_EVALUATED', 'bidder_evaluated');
+define('FC_TRADE_EXHIBITOR_EVALUATED', 'exhibitor_evaluated');
+define('FC_TRADE_ITEM_PASSED', 'item_passed');
+define('FC_TRADE_CONFIRMED', 'confirmed');
+define('FC_TRADE_GIVEMEED', 'givemed');
+define('FC_TRADE_ENTRIED', 'entried');
+
+function get_trade_status($id){
+	if(isFinish($id) && isBidderEvaluated($id) && isExhibiterEvaluated($id)){
+		return FC_TRADE_FINISHED;
+	}else if(isFinish($id) && isBidderEvaluated($id) && !isExhibiterEvaluated($id)){
+		return FC_TRADE_BIDDER_EVALUATED;
+	}else if(isFinish($id) && !isBidderEvaluated($id) && isExhibiterEvaluated($id)){
+		return FC_TRADE_EXHIBITOR_EVALUATED;
+	}else if(isFinish($id) && !isBidderEvaluated($id) && !isExhibiterEvaluated($id)){
+		return FC_TRADE_ITEM_PASSED;
+	}else if(!isFinish($id) && isConfirm($id)){
+		return FC_TRADE_CONFIRMED;
+	}else if(!isConfirm($id) && isGiveme($id)){
+		return FC_TRADE_GIVEMEED;
+	}else if(!isGiveme($id) && isEntry($id)){
+		return FC_TRADE_ENTRIED;
+	}
+
+}
+
+/**
+ * くださいの履歴を返します。
+ * @param {array} $options 検索条件
+ *	count: trueなら検索結果の件数を返します
+ *	period_from: 日付範囲検索の開始日付
+ * 	period_to: 日付範囲検索の終了日付
+ * @return {int/array} $result 検索結果
+ *	$options['count'] = true のとき int
+ *	それ以外のとき array[fmt_user_givemeオブジェクト]
+ */
+function get_giveme_log($options){
+	global $wpdb, $table_prefix;
+	$sql;
+	$result;
+	$where = [];
+	$bind_values = [];
+
+	if(isset($options['count']) && $options['count']){
+		$sql = "SELECT count(*) FROM {$table_prefix}fmt_user_giveme ";
+	}else{
+		$sql = "SELECT * FROM {$table_prefix}fmt_user_giveme ";
+	}
+
+	// 日付範囲検索条件構築部分
+	if(isset($options['period_from'])){
+		array_push($where, "insert_timestamp >= %s");
+		array_push($bind_values, $options['period_from']);
+	}
+
+	if(isset($options['period_to'])){
+		array_push($where, "insert_timestamp <= %s");
+		array_push($bind_values, $options['period_to']);
+	}	
+
+	if(count($where) > 0){
+		$sql .= 'WHERE ' . implode($where, ' and ');
+	}
+
+	if(isset($options['count']) && $options['count']){
+		$result = $wpdb->get_var($wpdb->prepare($sql, $bind_values));
+	}else{
+		$result = $wpdb->get_results($wpdb->prepare($sql, $bind_values));
+	}
+
+	return $result;
+}
+
+/**
+ * 取引の履歴を返します。
+ * 
+ * @param {array} $options 検索条件
+ * @return {int/array} $result 検索結果
+ *	$options['count'] = true のとき int
+ *	それ以外のとき array[fmt_user_givemeオブジェクト]
+ */
+function get_trade_log($options){
+	global $wpdb, $table_prefix;
+	$sql;
+	$result;
+	$where = [];
+	$bind_values = [];
+
+	if(isset($options['count']) && $options['count']){
+		$sql = "SELECT count(*) FROM {$table_prefix}fmt_giveme_state ";
+	}else{
+		$sql = "SELECT * FROM {$table_prefix}fmt_giveme_state ";
+	}
+
+	// 固定検索条件
+	array_push($where, "giveme_flg = 1 and entry_flg = 1");
+
+	// 状態検索条件構築部分
+	if(isset($options['state'])){
+		switch ($options['state']) {
+			case 'finished':
+				array_push($where, "finished_flg = 1 and bidder_evaluated_flg = 1
+					and exhibiter_evaluated_flg = 1 and confirmed_flg = 1");
+				break;
+			case 'bidder_evaluated':
+				array_push($where, "finished_flg = 1 and bidder_evaluated_flg = 1
+					and exhibiter_evaluated_flg = 0 and confirmed_flg = 1");
+				break;
+			case 'exhibitor_evaluated':
+				array_push($where, "finished_flg = 1 and bidder_evaluated_flg = 0
+					and exhibiter_evaluated_flg = 1 and confirmed_flg = 1");
+				break;
+			case 'item_passed':
+				array_push($where, "finished_flg = 1 and bidder_evaluated_flg = 0
+					and exhibiter_evaluated_flg = 0 and confirmed_flg = 1");
+				break;
+			case 'confirmed':
+				array_push($where, "finished_flg = 0 and bidder_evaluated_flg = 0
+					and exhibiter_evaluated_flg = 0 and confirmed_flg = 1");
+				break;
+			case 'giveme':
+				array_push($where, "finished_flg = 0 and bidder_evaluated_flg = 0
+					and exhibiter_evaluated_flg = 0 and confirmed_flg = 0");
+				break;
+			default:
+				break;
+		}
+	}	
+
+	// 日付範囲検索条件構築部分
+	if(isset($options['period_from'])){
+		array_push($where, "update_timestamp >= %s");
+		array_push($bind_values, $options['period_from']);
+	}
+
+	if(isset($options['period_to'])){
+		array_push($where, "update_timestamp <= %s");
+		array_push($bind_values, $options['period_to']);
+	}	
+
+	if(count($where) > 0){
+		$sql .= 'WHERE ' . implode($where, ' and ');
+	}
+
+	// 並べ替え
+	if(isset($options['order'])){
+		$order = ' ORDER BY';
+		foreach ($options['order'] as $k => $v){
+			$order .= " $k $v,";
+		}
+		$sql .= rtrim($order, ',');
+		//return $sql;
+	}	
+
+	// 検索件数上限
+	if(isset($options['limit'])){
+		$sql .= ' LIMIT %d';
+		array_push($bind_values, $options['limit']);
+	}
+
+	if(isset($options['count']) && $options['count']){
+		$result = $wpdb->get_var($wpdb->prepare($sql, $bind_values));
+	}else{
+		$result = $wpdb->get_results($wpdb->prepare($sql, $bind_values));
+	}
+
+	return $result;
+}

--- a/themes/freecycle/templates/setting.php
+++ b/themes/freecycle/templates/setting.php
@@ -14,6 +14,7 @@
 			'mail-magazine-setting' => 'メールマガジン',
 			'message-setting' => 'メッセージ',
 			'map-setting' => '取引場所',
+			'trade-log' => '取引履歴',
 		) as $key => $val):
 	?>
 	<a class="nav-tab<?php if(isset($_REQUEST['view']) && $_REQUEST['view'] == $key) echo ' nav-tab-active'; ?>" href="<?php echo admin_url('options-general.php?page=texchange&view='.$key);?>">
@@ -61,7 +62,10 @@
 		    break;
 		case 'map-setting-places-update':
 		    require_once dirname(__FILE__).DIRECTORY_SEPARATOR.'map-setting-places-update.php';
-		    break;		    
+		    break; 
+		case 'trade-log':
+		    require_once dirname(__FILE__).DIRECTORY_SEPARATOR.'trade-log.php';
+		    break; 
 		default:
     ?>
     <table class="form-table">

--- a/themes/freecycle/templates/trade-log.php
+++ b/themes/freecycle/templates/trade-log.php
@@ -1,0 +1,113 @@
+    <?php
+    	wp_nonce_field('update-options');
+    ?>
+    <h2>取引履歴</h2>
+    <table class="wp-list-table widefat fixed">
+    	<thead>
+			<tr valign="top">
+			<th class="manage-column"></th>
+			<th class="manage-column"><strong>今日</strong></th>
+			<th class="manage-column"><strong>最近1週間</strong></th>
+			<th class="manage-column"><strong>最近1ヶ月</strong></th>
+			</tr>
+		</thead>
+		<tr valign="top">
+		<td><strong>ください</strong></td>
+		<td><?php echo get_giveme_log([
+			"count"=>true,
+			"period_from"=>date_i18n('Y-m-d 00:00:00'),
+			"period_to"=>date_i18n('Y-m-d 23:59:59')]); ?>件</td>
+		<td><?php
+			// なぜかstrtotimeで日を計算すると一日ずれる……
+			echo get_giveme_log([
+			"count"=>true,
+			"period_from"=>date_i18n('Y-m-d 00:00:00', strtotime('- 5 day')),
+			"period_to"=>date_i18n('Y-m-d 23:59:59')]); ?>件</td>
+		<td><?php 
+			echo get_giveme_log([
+			"count"=>true,
+			"period_from"=>date_i18n('Y-m-d 00:00:00', strtotime('- 1 month')),
+			"period_to"=>date_i18n('Y-m-d 23:59:59')]); ?>件</td>
+		</tr>
+		<tr valign="top" class="">
+		<td><strong>取引完了</strong></td>
+		<td><?php echo get_trade_log([
+			"count"=>true,
+			"state"=>'finished',
+			"period_from"=>date_i18n('Y-m-d 00:00:00'),
+			"period_to"=>date_i18n('Y-m-d 23:59:59')]); ?>件</td>
+		<td><?php echo get_trade_log([
+			"count"=>true,
+			"state"=>'finished',
+			"period_from"=>date_i18n('Y-m-d 00:00:00', strtotime('- 5 day')),
+			"period_to"=>date_i18n('Y-m-d 23:59:59')]); ?>件</td>
+		<td><?php echo get_trade_log([
+			"count"=>true,
+			"state"=>'finished',
+			"period_from"=>date_i18n('Y-m-d 00:00:00', strtotime('- 1 month')),
+			"period_to"=>date_i18n('Y-m-d 23:59:59')]); ?>件</td>
+		</tr>
+    </table>
+	<br/>
+    <h2>最近の取引</h2>
+    <table class="wp-list-table widefat fixed">
+    	<thead>
+			<tr valign="top">
+			<th class="manage-column"><strong>商品名</strong></th>
+			<th class="manage-column"><strong>出品者</strong></th>
+			<th class="manage-column"><strong>取引相手</strong></th>
+			<th class="manage-column"><strong>最終更新日時</strong></th>
+			<th class="manage-column"><strong>状態</strong></th>
+			</tr>
+		</thead>
+		<tbody>
+			<?php
+				$count = 0;
+				$trade_logs = get_trade_log([
+					"limit"=>10,
+					"order"=>["update_timestamp"=>"DESC", "insert_timestamp"=>"DESC", "confirmed_flg"=>"ASC"]]);
+				foreach ($trade_logs as $trade_log) {
+					$class = $count%2==0?'':"class='alternate'";
+					$item = get_post($trade_log->post_id);
+					$item_link = home_url() . "/archives/" . $trade_log->post_id;
+					$exhibitor_link = bp_core_get_userlink($item->post_author);
+					$bidder_link = bp_core_get_userlink(get_bidder_id($trade_log->post_id));
+					$status = get_trade_status($trade_log->post_id);
+					$status_display;
+					switch ($status) {
+						case FC_TRADE_FINISHED:
+							$status_display = '取引完了';
+							break;
+						case FC_TRADE_BIDDER_EVALUATED:
+							$status_display = '取引相手評価済';
+							break;
+						case FC_TRADE_EXHIBITOR_EVALUATED:
+							$status_display = '出品者評価済';
+							break;
+						case FC_TRADE_ITEM_PASSED:
+							$status_display = '商品受け渡し済';
+							break;
+						case FC_TRADE_CONFIRMED:
+							$status_display = '取引相手確定済';
+							break;
+						case FC_TRADE_GIVEMEED:
+							$status_display = 'ください済';
+							break;
+						default:
+							// 
+							break;
+					}
+echo <<<ROW
+			<tr valign="top" $class>
+			<td><a href="$item_link">$item->post_title</a></td>
+			<td>$exhibitor_link</td>
+			<td>$bidder_link</td>
+			<td>$trade_log->update_timestamp</td>
+			<td>$status_display</td>
+			</tr>
+ROW;
+					$count++;
+				}
+			?>
+		</tbody>
+    </table>


### PR DESCRIPTION
取引履歴をダッシュボードから見られるようにする対応。設定->テクスチェンジ->取引履歴 タブから確認できます。

- 本日/直近1週間/直近1ヶ月 のくださいおよび完了取引件数を表示。
- 最新10件の取引履歴および状態を表示。