### PR TITLE
Fix the bug #141

### DIFF
--- a/themes/freecycle/single.php
+++ b/themes/freecycle/single.php
@@ -364,7 +364,10 @@
 		}
 
 		function afterFinish(){
+			// show a bidder evaluation form
 			jQuery("#finish").replaceWith('<div id="evaluation">落札者の評価:</br><select name="score" id="score"><option value="invalid" selected>--選択--</option><option value="5" >とても良い</option><option value="4" >良い</option><option value="3" >普通</option><option value="2" >悪い</option><option value="1" >とても悪い</option></select></br>コメント(任意 100字以内)</br><textarea name="trade_comment" id="trade_comment" rows="5" cols="40"></textarea></br><input type="button" id="evaluation" value="評価する" onClick="onBidderEvaluation();"></div>');
+			// hide a cancel trading link
+			jQuery('#cancelTradeFromExhibitor').hide();
 		}
 
 		function updateComment(commentID, updatedComment){


### PR DESCRIPTION
Hide a cancel trading link after the finish trading link clicked
取引完了リンクをクリックしたあとも取引キャンセルのリンクが出っぱなしになっていたバグを修正。
取引完了後の動きを一括で行っているafterFinish関数内で、取引キャンセルリンクをjQueryオブジェクトとして呼び出し、hideを実行することでリンクを消去している。